### PR TITLE
Fix default settings for DLI

### DIFF
--- a/sw/control/KFDtool.Gui/Settings.cs
+++ b/sw/control/KFDtool.Gui/Settings.cs
@@ -56,8 +56,8 @@ namespace KFDtool.Gui
         {
             Properties.Settings.Default.TwiComPort = "";
             Properties.Settings.Default.DliHostname = "192.168.128.1";
-            Properties.Settings.Default.DliPort = 0;
-            Properties.Settings.Default.DliVariant = "Standard";
+            Properties.Settings.Default.DliPort = 49644;
+            Properties.Settings.Default.DliVariant = "Motorola";
             Properties.Settings.Default.DeviceType = "TwiKfdDevice";
             Properties.Settings.Default.KfdDeviceType = "Kfdshield";
             Properties.Settings.Default.Save();


### PR DESCRIPTION
This was created in an [earlier commit](https://github.com/omahacommsys/KFDtool/commit/57756a9f1da418dc743a23f5f657f9c2a336bf56) and breaks DLI for users who don't have the port memorised. Fix it to default to Motorola as it did before.