### PR TITLE
Fix multiple keyloading bug

### DIFF
--- a/sw/control/KFDtool.Adapter/Protocol/Adapter/AdapterProtocol.cs
+++ b/sw/control/KFDtool.Adapter/Protocol/Adapter/AdapterProtocol.cs
@@ -83,7 +83,7 @@ namespace KFDtool.Adapter.Protocol.Adapter
                 throw new ArgumentException(String.Format("Unknown device type {0}", deviceType));
             }
 
-            TimeoutMs = 1000;
+            TimeoutMs = 2000;
         }
 
         public void Open()
@@ -825,7 +825,7 @@ namespace KFDtool.Adapter.Protocol.Adapter
             /*
             * RSP: SEND BYTES
             * 
-            * [0] RSP_SEND_BYTE
+            * [0] RSP_SEND_BYTES
             */
 
             if (rsp.Count == 1)
@@ -857,7 +857,10 @@ namespace KFDtool.Adapter.Protocol.Adapter
 
             if (FeatureAvailableSendBytes)
             {
-                const int dataBytesPerCommand = 500;
+                // We have a buffer of size 512 in the firmware; imagine a world where each byte
+                // happens to be one that needs to be escaped; size our maximum data in order to
+                // avoid overflowing our buffer.
+                const int dataBytesPerCommand = 250;
                 if (data.Count <= dataBytesPerCommand)
                 {
                     SendBytes(data);


### PR DESCRIPTION
Multiple keyloading has been broken for large numbers of keys since the introduction of `CMD_SEND_BYTES`. This is due to us overrunning a buffer on the adapter when too many bytes are sent to it when certain bytes have to be escaped in the message.

Reduce our maximum message size for `CMD_SEND_BYTES` to handle even the worst-case situation where *every* byte has to be escaped.

Tested on a KFDnano with 20 AES-256 keys with value `6161616161616161616161616161616161616161616161616161616161616161`. Observed that they loaded correctly, and the maximum message size logged was ~450 bytes.

Thanks to @duggerd for pointers on where to look for this.
