### PR TITLE
Add support for key sharing to KVL 4000

### DIFF
--- a/sw/control/KFDtool.Adapter/Protocol/Adapter/AdapterProtocol.cs
+++ b/sw/control/KFDtool.Adapter/Protocol/Adapter/AdapterProtocol.cs
@@ -857,9 +857,9 @@ namespace KFDtool.Adapter.Protocol.Adapter
 
             if (FeatureAvailableSendBytes)
             {
-                // We have a buffer of size 512 in the firmware; imagine a world where each byte
-                // happens to be one that needs to be escaped; size our maximum data in order to
-                // avoid overflowing our buffer.
+                // We have a command buffer of size 512 in the firmware; imagine a world where each
+                // byte happens to be one that needs to be escaped; size our maximum data in order
+                // to avoid overrunning our buffer.
                 const int dataBytesPerCommand = 250;
                 if (data.Count <= dataBytesPerCommand)
                 {

--- a/sw/control/KFDtool.P25/DataLinkIndependent/DataLinkIndependentProtocol.cs
+++ b/sw/control/KFDtool.P25/DataLinkIndependent/DataLinkIndependentProtocol.cs
@@ -30,7 +30,7 @@ namespace KFDtool.P25.DataLinkIndependent
             // not needed
         }
 
-        public void InitSession()
+        public DeviceType InitSession()
         {
             if (MotVariant)
             {
@@ -42,6 +42,8 @@ namespace KFDtool.P25.DataLinkIndependent
             {
                 SendReadyRequest();
             }
+
+            return DeviceType.Mr;
         }
 
         public void EndSession()

--- a/sw/control/KFDtool.P25/DeviceProtocol/DeviceType.cs
+++ b/sw/control/KFDtool.P25/DeviceProtocol/DeviceType.cs
@@ -1,0 +1,8 @@
+﻿namespace KFDtool.P25.DeviceProtocol
+{
+    public enum DeviceType
+    {
+        Mr,
+        Kvl,
+    }
+}

--- a/sw/control/KFDtool.P25/DeviceProtocol/IDeviceProtocol.cs
+++ b/sw/control/KFDtool.P25/DeviceProtocol/IDeviceProtocol.cs
@@ -10,7 +10,7 @@ namespace KFDtool.P25.DeviceProtocol
     {
         void SendKeySignature();
 
-        void InitSession();
+        DeviceType InitSession();
 
         void CheckTargetMrConnection();
 

--- a/sw/control/KFDtool.P25/KFDtool.P25.csproj
+++ b/sw/control/KFDtool.P25/KFDtool.P25.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Kmm\SessionControl.cs" />
     <Compile Include="NetworkProtocol\UdpProtocol.cs" />
     <Compile Include="Partition\KeyPartitioner.cs" />
+    <Compile Include="DeviceProtocol\DeviceType.cs" />
     <Compile Include="TransferConstructs\CmdKeyItem.cs" />
     <Compile Include="TransferConstructs\DliIpDevice.cs" />
     <Compile Include="TransferConstructs\BaseDevice.cs" />

--- a/sw/control/KFDtool.P25/Partition/KeyPartitioner.cs
+++ b/sw/control/KFDtool.P25/Partition/KeyPartitioner.cs
@@ -9,6 +9,8 @@ namespace KFDtool.P25.Partition
 {
     public class KeyPartitioner
     {
+        public const int MAX_BYTES = 512;
+
         private static void CheckForDifferentKeyLengths(List<CmdKeyItem> inKeys)
         {
             Dictionary<int, int> len = new Dictionary<int, int>();
@@ -29,11 +31,9 @@ namespace KFDtool.P25.Partition
             }
         }
 
-        private static int CalcMaxKeysPerKmm(int keyLength)
+        private static int CalcMaxKeysPerKmm(int keyLength, int maxBytes)
         {
             // TODO make this calc more dynamic
-
-            int maxBytes = 512;
             int availBytes = maxBytes - 27;
 
             int keyItemBytes = 5 + keyLength;
@@ -48,7 +48,7 @@ namespace KFDtool.P25.Partition
             return maxKeys;
         }
 
-        private static void PartitionByAlg(List<CmdKeyItem> inKeys, List<List<CmdKeyItem>> outKeys)
+        private static void PartitionByAlg(List<CmdKeyItem> inKeys, List<List<CmdKeyItem>> outKeys, int maxBytes)
         {
             Dictionary<int, List<CmdKeyItem>> alg = new Dictionary<int, List<CmdKeyItem>>();
 
@@ -64,7 +64,7 @@ namespace KFDtool.P25.Partition
 
             foreach (KeyValuePair<int, List<CmdKeyItem>> algGroup in alg)
             {
-                int maxKeys = CalcMaxKeysPerKmm(algGroup.Value[0].Key.Count);
+                int maxKeys = CalcMaxKeysPerKmm(algGroup.Value[0].Key.Count, maxBytes);
 
                 PartitionByType(maxKeys, algGroup.Value, outKeys);
             }
@@ -142,13 +142,13 @@ namespace KFDtool.P25.Partition
             }
         }
 
-        public static List<List<CmdKeyItem>> PartitionKeys(List<CmdKeyItem> inKeys)
+        public static List<List<CmdKeyItem>> PartitionKeys(List<CmdKeyItem> inKeys, int maxBytes = MAX_BYTES)
         {
             CheckForDifferentKeyLengths(inKeys);
 
             List<List<CmdKeyItem>> outKeys = new List<List<CmdKeyItem>>();
 
-            PartitionByAlg(inKeys, outKeys);
+            PartitionByAlg(inKeys, outKeys, maxBytes);
 
             return outKeys;
         }

--- a/sw/control/KFDtool.P25/ThreeWire/ThreeWireProtocol.cs
+++ b/sw/control/KFDtool.P25/ThreeWire/ThreeWireProtocol.cs
@@ -19,7 +19,8 @@ namespace KFDtool.P25.ThreeWire
         private const int TIMEOUT_STD = 5000; // 5 second timeout
 
         private const byte OPCODE_READY_REQ = 0xC0;
-        private const byte OPCODE_READY_GENERAL_MODE = 0xD0;
+        private const byte OPCODE_READY_GENERAL_MODE_MR = 0xD0;
+        private const byte OPCODE_READY_GENERAL_MODE_KVL = 0xD1;
         private const byte OPCODE_TRANSFER_DONE = 0xC1;
         private const byte OPCODE_KMM = 0xC2;
         private const byte OPCODE_DISCONNECT_ACK = 0x90;
@@ -38,7 +39,7 @@ namespace KFDtool.P25.ThreeWire
             Protocol.SendKeySignature();
         }
 
-        public void InitSession()
+        public DeviceType InitSession()
         {
             // send ready req opcode
             List<byte> cmd = new List<byte>();
@@ -51,9 +52,11 @@ namespace KFDtool.P25.ThreeWire
             Log.Debug("mr: ready general mode");
             byte rsp = Protocol.GetByte(TIMEOUT_STD);
             Log.Debug("kfd -> mr: {0}", Utility.DataFormat(rsp));
-            if (rsp != OPCODE_READY_GENERAL_MODE)
+            switch (rsp)
             {
-                throw new Exception("mr: unexpected opcode");
+                case OPCODE_READY_GENERAL_MODE_MR: return DeviceType.Mr;
+                case OPCODE_READY_GENERAL_MODE_KVL: return DeviceType.Kvl;
+                default: throw new Exception("mr: unexpected opcode");
             }
         }
 
@@ -365,8 +368,8 @@ namespace KFDtool.P25.ThreeWire
                     /* TX: READY GENERAL MODE */
 
                     Log.Debug("out: ready general mode opcode");
-                    Log.Trace("out: {0}", Utility.DataFormat(OPCODE_READY_GENERAL_MODE));
-                    Protocol.SendByte(OPCODE_READY_GENERAL_MODE);
+                    Log.Trace("out: {0}", Utility.DataFormat(OPCODE_READY_GENERAL_MODE_MR));
+                    Protocol.SendByte(OPCODE_READY_GENERAL_MODE_MR);
 
                     while (true)
                     {


### PR DESCRIPTION
This commit introduces support for key sharing from KFDtool software to the Motorola KVL 4000.

Sharing is implemented as an automatic feature when using Keyload or Multiple Keyload functionality; the software detects whether the connected device is a KVL, and adjusts its behaviour appropriately.

The main differences are a new opcode (`D1` indicating a KVL vs `D0` indicating an MR), and limiting the KMM size for transfers to a KVL.

The latter is required because the KFD* hardware has a limited onboard buffer, and the KVL does not like when there is too much delay between bytes on the TWI data line. A limited KMM size avoids calls being split over multiple CMD_SEND_BYTES commands.