### PR TITLE
Add native-USB device type to unbreak DTR setting

### DIFF
--- a/sw/control/KFDtool.Adapter/Device/TwiKfdDevice.cs
+++ b/sw/control/KFDtool.Adapter/Device/TwiKfdDevice.cs
@@ -8,8 +8,8 @@ namespace KFDtool.Adapter.Device
 {
     public enum TwiKfdDevice
     {
-        Kfdtool,
-        Kfdshield,
-        Kfdmicro
+        KfdTool,
+        KfdShield,
+        KfdUsb
     }
 }

--- a/sw/control/KFDtool.Adapter/Protocol/Adapter/AdapterProtocol.cs
+++ b/sw/control/KFDtool.Adapter/Protocol/Adapter/AdapterProtocol.cs
@@ -70,13 +70,17 @@ namespace KFDtool.Adapter.Protocol.Adapter
 
         public AdapterProtocol(string portName, TwiKfdDevice deviceType)
         {
-            if (deviceType == TwiKfdDevice.Kfdtool)
+            if (deviceType == TwiKfdDevice.KfdTool)
             {
                 Lower = new KfdToolSerialProtocol(portName);
             }
-            else if (deviceType == TwiKfdDevice.Kfdshield || deviceType == TwiKfdDevice.Kfdmicro)
+            else if (deviceType == TwiKfdDevice.KfdShield)
             {
                 Lower = new KfdShieldSerialProtocol(portName);
+            }
+            else if (deviceType == TwiKfdDevice.KfdUsb)
+            {
+                Lower = new KfdShieldSerialProtocol(portName, dtrEnabled: true);
             }
             else
             {

--- a/sw/control/KFDtool.Adapter/Protocol/Serial/KfdShieldSerialProtocol.cs
+++ b/sw/control/KFDtool.Adapter/Protocol/Serial/KfdShieldSerialProtocol.cs
@@ -31,7 +31,7 @@ namespace KFDtool.Adapter.Protocol.Serial
 
         private SerialPort Port;
 
-        public KfdShieldSerialProtocol(string portName)
+        public KfdShieldSerialProtocol(string portName, bool dtrEnabled = false)
         {
             FrameBuffer = new List<byte>();
 
@@ -47,8 +47,11 @@ namespace KFDtool.Adapter.Protocol.Serial
             Port.DataBits = 8;
             Port.StopBits = StopBits.One;
             // Certain USB-based KFD devices require DTR to be set before they will respond to commands
-            Port.DtrEnable = true;
-            
+            if (dtrEnabled)
+            {
+                Port.DtrEnable = true;
+            }
+
             Port.DataReceived += new SerialDataReceivedEventHandler(OnDataReceived);
         }
 

--- a/sw/control/KFDtool.Cmd/Analyzer.cs
+++ b/sw/control/KFDtool.Cmd/Analyzer.cs
@@ -12,7 +12,7 @@ namespace KFDtool.Cmd
     {
         public static void FreeRunRead(string port)
         {
-            TwiKfdDevice device = TwiKfdDevice.Kfdtool;
+            TwiKfdDevice device = TwiKfdDevice.KfdTool;
             AdapterProtocol ap = new AdapterProtocol(port, device);
 
             Task.Run(() =>

--- a/sw/control/KFDtool.Gui/MainWindow.xaml
+++ b/sw/control/KFDtool.Gui/MainWindow.xaml
@@ -22,9 +22,9 @@
                     <MenuItem Header="_Close" Click="Container_Close_Click"/>
                 </MenuItem>
                 <MenuItem Name="TypeMenu" Header="_Type">
-                    <MenuItem Name="TypeTwiKfdtool" Header="_TWI (KFDtool)" Click="Type_MenuItem_Click" />
-                    <MenuItem Name="TypeTwiKfdshield" Header="_TWI (KFDshield)" Click="Type_MenuItem_Click" />
-                    <MenuItem Name="TypeTwiKfdmicro" Header="_TWI (KFDmicro)" Click="Type_MenuItem_Click" />
+                    <MenuItem Name="TypeTwiKfdTool" Header="_TWI (KFDtool)" Click="Type_MenuItem_Click" />
+                    <MenuItem Name="TypeTwiKfdShield" Header="_TWI (KFDshield)" Click="Type_MenuItem_Click" />
+                    <MenuItem Name="TypeTwiKfdUsb" Header="_TWI (KFD USB)" Click="Type_MenuItem_Click" />
                     <MenuItem Name="TypeDliIp" Header="_DLI (IP)" Click="Type_MenuItem_Click" />
                 </MenuItem>
                 <MenuItem Name="DeviceMenu" Header="_Device" />

--- a/sw/control/KFDtool.Gui/MainWindow.xaml.cs
+++ b/sw/control/KFDtool.Gui/MainWindow.xaml.cs
@@ -60,24 +60,24 @@ namespace KFDtool.Gui
                         // Select the appropriate device type based on loaded settings
                         switch (Settings.SelectedDevice.KfdDeviceType)
                         {
-                            case TwiKfdDevice.Kfdshield:
+                            case TwiKfdDevice.KfdShield:
                                 {
-                                    SwitchType(TypeTwiKfdshield);
+                                    SwitchType(TypeTwiKfdShield);
                                     break;
                                 }
-                            case TwiKfdDevice.Kfdtool:
+                            case TwiKfdDevice.KfdTool:
                                 {
-                                    SwitchType(TypeTwiKfdtool);
+                                    SwitchType(TypeTwiKfdTool);
                                     break;
                                 }
-                            case TwiKfdDevice.Kfdmicro:
+                            case TwiKfdDevice.KfdUsb:
                                 {
-                                    SwitchType(TypeTwiKfdmicro);
+                                    SwitchType(TypeTwiKfdUsb);
                                     break;
                                 }
                             default:
                                 {
-                                    SwitchType(TypeTwiKfdtool);
+                                    SwitchType(TypeTwiKfdTool);
                                     break;
                                 }
                         }
@@ -578,34 +578,34 @@ namespace KFDtool.Gui
 
             mi.IsChecked = true;
 
-            if (mi.Name == "TypeTwiKfdtool")
+            if (mi.Name == "TypeTwiKfdTool")
             {
                 DeviceMenu.Items.Clear();
 
                 Settings.SelectedDevice.DeviceType = BaseDevice.DeviceTypeOptions.TwiKfdDevice;
-                Settings.SelectedDevice.KfdDeviceType = TwiKfdDevice.Kfdtool;
+                Settings.SelectedDevice.KfdDeviceType = TwiKfdDevice.KfdTool;
 
                 ResetTwiDeviceInfo();
 
                 StartAppDet();
             }
-            else if (mi.Name == "TypeTwiKfdshield")
+            else if (mi.Name == "TypeTwiKfdShield")
             {
                 DeviceMenu.Items.Clear();
 
                 Settings.SelectedDevice.DeviceType = BaseDevice.DeviceTypeOptions.TwiKfdDevice;
-                Settings.SelectedDevice.KfdDeviceType = TwiKfdDevice.Kfdshield;
+                Settings.SelectedDevice.KfdDeviceType = TwiKfdDevice.KfdShield;
 
                 ResetTwiDeviceInfo();
 
                 StartAppDet();
             }
-            else if (mi.Name == "TypeTwiKfdmicro")
+            else if (mi.Name == "TypeTwiKfdUsb")
             {
                 DeviceMenu.Items.Clear();
 
                 Settings.SelectedDevice.DeviceType = BaseDevice.DeviceTypeOptions.TwiKfdDevice;
-                Settings.SelectedDevice.KfdDeviceType = TwiKfdDevice.Kfdmicro;
+                Settings.SelectedDevice.KfdDeviceType = TwiKfdDevice.KfdUsb;
 
                 ResetTwiDeviceInfo();
 


### PR DESCRIPTION
The previous commit (6a5035ebf5477099179c587eeee0b1258b495dcc) unfortunately turns out to have broken support for legacy KFD* devices that rely on USB-to-serial adapters - i.e. mostly AVR-architecture devices such as the KFDshield, KFDnano, KFDmicro, and older-firmware versions of the KFDpico.

Make this new setting configurable to support new native-USB devices such as the newer-firmware version of the KFDpico and future SAMD-architecture devices.

In the process, remove the KFDmicro device type to reduce user confusion as it is simply an alias for KFDshield.

Tested on a KFDmicro, KFDnano (Rust firmware), and a future SAMD-architecture device.