### PR TITLE
Temporarily disable adapter proto version checking

### DIFF
--- a/sw/control/KFDtool.Gui/MainWindow.xaml.cs
+++ b/sw/control/KFDtool.Gui/MainWindow.xaml.cs
@@ -846,15 +846,15 @@ namespace KFDtool.Gui
 
                 Version apVersion = new Version(apVerStr);
 
-                if (apVersion.Major != 2)    // TODO: handle this better
-                {
-                    MessageBox.Show(string.Format(
-                        "Adapter protocol version not compatible ({0})\n\n" +
-                        "This version of KFDtool supports adapter protocol versions 2.x.x.\n\n" +
-                        "Please update your adapter firmware.",
-                        apVerStr), "Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                    return;
-                }
+                // if (apVersion.Major != 2)    // TODO: handle this better
+                // {
+                //     MessageBox.Show(string.Format(
+                //         "Adapter protocol version not compatible ({0})\n\n" +
+                //         "This version of KFDtool supports adapter protocol versions 2.x.x.\n\n" +
+                //         "Please update your adapter firmware.",
+                //         apVerStr), "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                //     return;
+                // }
 
                 string fwVersion = string.Empty;
                 string uniqueId = string.Empty;


### PR DESCRIPTION
Reference issue #23 - original KFDtools are not connecting due to an adapter protocol version conflict (AVR-based tools use 2.0; original ones use 1.0). For now, to enable user functionality, let's disable the check. Later when the application is reworked the adapter protocol checks can be done at the device driver level rather than an application level.