### PR TITLE
Introduce SEND_KEY_SIGNATURE_AND_READY_REQ command

### DIFF
--- a/sw/control/KFDtool.Adapter/Protocol/Adapter/AdapterProtocol.cs
+++ b/sw/control/KFDtool.Adapter/Protocol/Adapter/AdapterProtocol.cs
@@ -20,6 +20,7 @@ namespace KFDtool.Adapter.Protocol.Adapter
         private const byte CMD_SEND_KEY_SIG = 0x16;
         private const byte CMD_SEND_BYTE = 0x17;
         private const byte CMD_SEND_BYTES = 0x18;
+        private const byte CMD_SEND_KEY_SIG_AND_READY_REQ = 0x19;
 
         /* RESPONSE OPCODES */
         private const byte RSP_ERROR = 0x20;
@@ -31,6 +32,7 @@ namespace KFDtool.Adapter.Protocol.Adapter
         private const byte RSP_SEND_KEY_SIG = 0x26;
         private const byte RSP_SEND_BYTE = 0x27;
         private const byte RSP_SEND_BYTES = 0x28;
+        private const byte RSP_SEND_KEY_SIG_AND_READY_REQ = 0x29;
 
         /* BROADCAST OPCODES */
         private const byte BCST_RECEIVE_BYTE = 0x31;
@@ -67,6 +69,7 @@ namespace KFDtool.Adapter.Protocol.Adapter
         private Version ProtocolVersion;
         private bool FeatureAvailableSendBytes => ProtocolVersion >= new Version(2, 1, 0);
         private bool FeatureAvailableSetTransferSpeed => ProtocolVersion >= new Version(2, 1, 0);
+        public bool FeatureAvailableSendKeySignatureAndReadyReq => ProtocolVersion >= new Version(2, 2, 0);
 
         public AdapterProtocol(string portName, TwiKfdDevice deviceType)
         {
@@ -753,6 +756,44 @@ namespace KFDtool.Adapter.Protocol.Adapter
             if (rsp.Count == 1)
             {
                 if (rsp[0] != RSP_SEND_KEY_SIG)
+                {
+                    throw new Exception("invalid response opcode");
+                }
+            }
+            else
+            {
+                throw new Exception("invalid response length");
+            }
+        }
+
+        public void SendKeySignatureAndReadyReq()
+        {
+            Debug.WriteLine("Sending key signature and ready req");
+            List<byte> cmd = new List<byte>();
+
+            /*
+            * CMD: SEND KEY SIGNATURE AND READY REQ
+            * 
+            * [0] CMD_SEND_KEY_SIG_AND_READY_REQ
+            * [1] reserved (set to 0x00)
+            */
+
+            cmd.Add(CMD_SEND_KEY_SIG_AND_READY_REQ);
+            cmd.Add(0x00);
+
+            Lower.Send(cmd);
+
+            List<byte> rsp = Lower.Read(TimeoutMs);
+
+            /*
+            * RSP: SEND KEY SIGNATURE AND READY REQ
+            * 
+            * [0] RSP_SEND_KEY_SIG_AND_READY_REQ
+            */
+
+            if (rsp.Count == 1)
+            {
+                if (rsp[0] != RSP_SEND_KEY_SIG_AND_READY_REQ)
                 {
                     throw new Exception("invalid response opcode");
                 }

--- a/sw/control/KFDtool.P25/ThreeWire/ThreeWireProtocol.cs
+++ b/sw/control/KFDtool.P25/ThreeWire/ThreeWireProtocol.cs
@@ -35,18 +35,29 @@ namespace KFDtool.P25.ThreeWire
 
         public void SendKeySignature()
         {
-            Log.Debug("kfd: key signature");
-            Protocol.SendKeySignature();
+            if (Protocol.FeatureAvailableSendKeySignatureAndReadyReq)
+            {
+                Log.Debug("kfd: key signature and ready req");
+                Protocol.SendKeySignatureAndReadyReq();
+            }
+            else
+            {
+                Log.Debug("kfd: key signature");
+                Protocol.SendKeySignature();
+            }
         }
 
         public DeviceType InitSession()
         {
-            // send ready req opcode
-            List<byte> cmd = new List<byte>();
-            cmd.Add(OPCODE_READY_REQ);
-            Log.Debug("kfd: ready req");
-            Log.Debug("kfd -> mr: {0}", Utility.DataFormat(cmd));
-            Protocol.SendData(cmd);
+            if (!Protocol.FeatureAvailableSendKeySignatureAndReadyReq)
+            {
+                // send ready req opcode
+                List<byte> cmd = new List<byte>();
+                cmd.Add(OPCODE_READY_REQ);
+                Log.Debug("kfd: ready req");
+                Log.Debug("kfd -> mr: {0}", Utility.DataFormat(cmd));
+                Protocol.SendData(cmd);
+            }
 
             // receive ready general mode opcode
             Log.Debug("mr: ready general mode");


### PR DESCRIPTION
This commit introduces a new `SEND_KEY_SIGNATURE_AND_READY_REQ` command to the adapter protocol, and bumps the protocol version to 2.2.0.

This command allows a key signature to be automatically followed by a `C0` ready req message.

By doing this in one command, the variable latency of the round-trip to the software is removed, which resolves some latency-sensitive bugs in the Kenwood NX and VP series radios.

At this time, the adapter firmware does not include this command; however it was tested on the Rust reference implementation that will be published prior to this PR being merged.

cc @rentfrowj, @alexhanyuan